### PR TITLE
User Fields for Instagram and Twitter accounts

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -28,6 +28,7 @@ endif::[]
 * Import your contacts from Google Contacts
 * Automatic list sorting
 * Add pictures to every contact
+* Add your contacts' Instagram and Twitter accounts
 
 ====
 

--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -43,7 +43,7 @@ e.g. typing *`help`* and pressing kbd:[Enter] will open the help window.
 == Features
 
 ====
-*Since v1.3*
+*Since v1.4*
 
 * Simply add a person with their name and number!
 * Export individual contacts to easily share with others
@@ -54,6 +54,7 @@ e.g. typing *`help`* and pressing kbd:[Enter] will open the help window.
 * Import your contacts from Google Contacts
 * Automatic list sorting
 * Add pictures to every contact
+* Add your contacts' Instagram and Twitter accounts
 
 ====
 
@@ -86,7 +87,7 @@ Format: `help`
 
 Adds a person to the address book +
 
-Format: `add n/NAME p/PHONE_NUMBER [e/EMAIL] [a/ADDRESS] [b/BIRTHDAY] [dp/CHOICE] [t/TAG]...`
+Format: `add n/NAME p/PHONE_NUMBER [e/EMAIL] [a/ADDRESS] [b/BIRTHDAY] [tw/TWITTER] [ig/INSTAGRAM] [dp/CHOICE] [t/TAG]...`
 
 =======
 [TIP]
@@ -102,8 +103,8 @@ The address book is sorted alphabetically after the person is added.
 =======
 Examples:
 
-* `add n/John Doe p/98765432 e/johnd@example.com a/John street, block 123, #01-01, b/19/09/1999 dp/Y`
-* `add n/Betsy Crowe t/friend e/betsycrowe@example.com a/Newgate Prison p/1234567, b/25/06/1994 t/criminal`
+* `add n/John Doe p/98765432 e/johnd@example.com a/John street, block 123, #01-01 b/19/09/1999 tw/john_doe dp/Y`
+* `add n/Betsy Crowe t/friend e/betsycrowe@example.com a/Newgate Prison p/1234567 b/25/06/1994 ig/crowe_94 t/criminal`
 
 === Listing all persons : `list`
 
@@ -113,7 +114,8 @@ Format: `list`
 === Editing a person : `edit`
 
 Edits an existing person in the address book. +
-Format: `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [b/BIRTHDAY] [dp/CHOICE] [t/TAG]...`
+Format: `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [b/BIRTHDAY] [tw/TWITTER]
+[ig/INSTAGRAM] [dp/CHOICE] [t/TAG]...`
 
 ****
 * Edits the person at the specified `INDEX`. The index refers to the index number shown in the last person listing. The index *must be a positive integer* 1, 2, 3, ...

--- a/src/main/java/seedu/address/MainApp.java
+++ b/src/main/java/seedu/address/MainApp.java
@@ -41,7 +41,7 @@ import seedu.address.ui.UiManager;
  */
 public class MainApp extends Application {
 
-    public static final Version VERSION = new Version(0, 6, 0, true);
+    public static final Version VERSION = new Version(1, 4, 0, true);
 
     private static final Logger logger = LogsCenter.getLogger(MainApp.class);
     private static HostServices hostServices;

--- a/src/main/java/seedu/address/commons/core/Config.java
+++ b/src/main/java/seedu/address/commons/core/Config.java
@@ -11,7 +11,7 @@ public class Config {
     public static final String DEFAULT_CONFIG_FILE = "config.json";
 
     // Config values customizable through config file
-    private String appTitle = "Address App";
+    private String appTitle = "HitMeUp";
     private Level logLevel = Level.INFO;
     private String userPrefsFilePath = "preferences.json";
 

--- a/src/main/java/seedu/address/commons/util/GoogleUtil.java
+++ b/src/main/java/seedu/address/commons/util/GoogleUtil.java
@@ -30,6 +30,7 @@ import seedu.address.logic.commands.ImportCommand;
 import seedu.address.model.person.DisplayPic;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Phone;
+import seedu.address.model.person.UserName;
 import seedu.address.model.tag.Tag;
 import seedu.address.model.util.SampleDataUtil;
 import seedu.address.ui.CommandBox;
@@ -152,7 +153,8 @@ public class GoogleUtil {
         seedu.address.model.person.Person toAdd;
         toAdd = new seedu.address.model.person.Person(nameAdd,
                 new Phone(phone), new Email(email), new seedu.address.model.person.Address(address),
-                new seedu.address.model.person.Birthday(birthday), new DisplayPic(CommandBox.DEFAULT_DISPLAY_PIC),
+                new seedu.address.model.person.Birthday(birthday), new UserName(""), new UserName(""),
+                new DisplayPic(CommandBox.DEFAULT_DISPLAY_PIC),
                 defaultTags);
         return toAdd;
     }

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -5,9 +5,11 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_BIRTHDAY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DP;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_INSTAGRAM;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TWITTER;
 
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.person.Person;
@@ -36,6 +38,8 @@ public class AddCommand extends UndoableCommand {
             + PREFIX_EMAIL + "johnd@example.com "
             + PREFIX_ADDRESS + "311, Clementi Ave 2, #02-25 "
             + PREFIX_BIRTHDAY + "25/06/1997 "
+            + PREFIX_TWITTER + "john.doe "
+            + PREFIX_INSTAGRAM + "john.doe "
             + PREFIX_DP + "YES "
             + PREFIX_TAG + "friends "
             + PREFIX_TAG + "owesMoney";

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -5,9 +5,11 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_BIRTHDAY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DP;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_INSTAGRAM;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TWITTER;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.List;
@@ -26,6 +28,7 @@ import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
 import seedu.address.model.person.ReadOnlyPerson;
+import seedu.address.model.person.UserName;
 import seedu.address.model.person.exceptions.DuplicatePersonException;
 import seedu.address.model.person.exceptions.PersonNotFoundException;
 import seedu.address.model.tag.Tag;
@@ -46,6 +49,8 @@ public class EditCommand extends UndoableCommand {
             + "[" + PREFIX_EMAIL + "EMAIL] "
             + "[" + PREFIX_ADDRESS + "ADDRESS] "
             + "[" + PREFIX_BIRTHDAY + "BIRTHDAY] "
+            + "[" + PREFIX_TWITTER  + "TWITTER] "
+            + "[" + PREFIX_INSTAGRAM + "INSTAGRAM] "
             + "[" + PREFIX_DP + "CHOICE] "
             + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " 1 "
@@ -107,11 +112,13 @@ public class EditCommand extends UndoableCommand {
         Email updatedEmail = editPersonDescriptor.getEmail().orElse(personToEdit.getEmail());
         Address updatedAddress = editPersonDescriptor.getAddress().orElse(personToEdit.getAddress());
         Birthday updatedBirthday = editPersonDescriptor.getBirthday().orElse(personToEdit.getBirthday());
+        UserName updatedTwitter = editPersonDescriptor.getTwitterName().orElse(personToEdit.getTwitterName());
+        UserName updatedInstagram = editPersonDescriptor.getInstagramName().orElse(personToEdit.getInstagramName());
         DisplayPic updatedDisplayPic = editPersonDescriptor.getDisplayPic().orElse(personToEdit.getDisplayPic());
         Set<Tag> updatedTags = editPersonDescriptor.getTags().orElse(personToEdit.getTags());
 
-        return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedBirthday,
-                updatedDisplayPic, updatedTags);
+        return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedBirthday, updatedTwitter,
+                updatedInstagram, updatedDisplayPic, updatedTags);
     }
 
     @Override
@@ -142,6 +149,8 @@ public class EditCommand extends UndoableCommand {
         private Email email;
         private Address address;
         private Birthday birthday;
+        private UserName twitterName;
+        private UserName instagramName;
         private DisplayPic displayPic;
         private Set<Tag> tags;
 
@@ -153,6 +162,8 @@ public class EditCommand extends UndoableCommand {
             this.email = toCopy.email;
             this.address = toCopy.address;
             this.birthday = toCopy.birthday;
+            this.twitterName = toCopy.twitterName;
+            this.instagramName = toCopy.instagramName;
             this.displayPic = toCopy.displayPic;
             this.tags = toCopy.tags;
         }
@@ -162,7 +173,7 @@ public class EditCommand extends UndoableCommand {
          */
         public boolean isAnyFieldEdited() {
             return CollectionUtil.isAnyNonNull(this.name, this.phone, this.email, this.address,
-                    this.birthday, this.displayPic, this.tags);
+                    this.birthday, this.twitterName, this.instagramName, this.displayPic, this.tags);
         }
 
         public void setName(Name name) {
@@ -203,6 +214,22 @@ public class EditCommand extends UndoableCommand {
 
         public Optional<Birthday> getBirthday() {
             return Optional.ofNullable(birthday);
+        }
+
+        public void setTwitterName(UserName twitterName) {
+            this.twitterName = twitterName;
+        }
+
+        public Optional<UserName> getTwitterName() {
+            return Optional.ofNullable(twitterName);
+        }
+
+        public void setInstagramName(UserName instagramName) {
+            this.instagramName = instagramName;
+        }
+
+        public Optional<UserName> getInstagramName() {
+            return Optional.ofNullable(instagramName);
         }
 
         public void setDisplayPic(DisplayPic displayPic) {

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -5,9 +5,11 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_BIRTHDAY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DP;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_INSTAGRAM;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TWITTER;
 import static seedu.address.ui.CommandBox.DEFAULT_DISPLAY_PIC;
 
 import java.util.Set;
@@ -24,6 +26,7 @@ import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
 import seedu.address.model.person.ReadOnlyPerson;
+import seedu.address.model.person.UserName;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -40,7 +43,7 @@ public class AddCommandParser implements Parser<AddCommand> {
     public AddCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
-                        PREFIX_BIRTHDAY, PREFIX_DP, PREFIX_TAG);
+                        PREFIX_BIRTHDAY, PREFIX_TWITTER, PREFIX_INSTAGRAM, PREFIX_DP, PREFIX_TAG);
 
         if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_PHONE)) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
@@ -54,10 +57,13 @@ public class AddCommandParser implements Parser<AddCommand> {
             Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL)).get();
             Address address = ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS)).get();
             Birthday birthday = ParserUtil.parseBirthday(argMultimap.getValue(PREFIX_BIRTHDAY)).get();
+            UserName twitterUser = ParserUtil.parseTwitterName(argMultimap.getValue(PREFIX_TWITTER)).get();
+            UserName instagramUser = ParserUtil.parseInstagramName(argMultimap.getValue(PREFIX_INSTAGRAM)).get();
             DisplayPic displayPic = ParserUtil.parseDisplayPic(argMultimap.getValue(PREFIX_DP)).get();
             Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
 
-            ReadOnlyPerson person = new Person(name, phone, email, address, birthday, displayPic, tagList);
+            ReadOnlyPerson person = new Person(name, phone, email, address, birthday, twitterUser,
+                    instagramUser, displayPic, tagList);
 
             return new AddCommand(person);
         } catch (IllegalValueException ive) {
@@ -86,6 +92,12 @@ public class AddCommandParser implements Parser<AddCommand> {
         }
         if (!argumentMultimap.getValue(PREFIX_BIRTHDAY).isPresent()) {
             argumentMultimap.put(PREFIX_BIRTHDAY, "");
+        }
+        if (!argumentMultimap.getValue(PREFIX_TWITTER).isPresent()) {
+            argumentMultimap.put(PREFIX_TWITTER, "");
+        }
+        if (!argumentMultimap.getValue(PREFIX_INSTAGRAM).isPresent()) {
+            argumentMultimap.put(PREFIX_INSTAGRAM, "");
         }
         if (!argumentMultimap.getValue(PREFIX_DP).isPresent()) {
             argumentMultimap.put(PREFIX_DP, DEFAULT_DISPLAY_PIC);

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -11,6 +11,8 @@ public class CliSyntax {
     public static final Prefix PREFIX_EMAIL = new Prefix("e/");
     public static final Prefix PREFIX_ADDRESS = new Prefix("a/");
     public static final Prefix PREFIX_BIRTHDAY = new Prefix("b/");
+    public static final Prefix PREFIX_TWITTER = new Prefix("tw/");
+    public static final Prefix PREFIX_INSTAGRAM = new Prefix("ig/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
     public static final Prefix PREFIX_DP = new Prefix("dp/");
 

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -6,9 +6,11 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_BIRTHDAY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DP;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_INSTAGRAM;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TWITTER;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -36,7 +38,8 @@ public class EditCommandParser implements Parser<EditCommand> {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
-                        PREFIX_ADDRESS, PREFIX_BIRTHDAY, PREFIX_DP, PREFIX_TAG);
+                        PREFIX_ADDRESS, PREFIX_BIRTHDAY, PREFIX_TWITTER,
+                        PREFIX_INSTAGRAM, PREFIX_DP, PREFIX_TAG);
 
         Index index;
 
@@ -54,6 +57,10 @@ public class EditCommandParser implements Parser<EditCommand> {
             ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS)).ifPresent(editPersonDescriptor::setAddress);
             ParserUtil.parseBirthday(argMultimap.getValue(PREFIX_BIRTHDAY))
                     .ifPresent(editPersonDescriptor::setBirthday);
+            ParserUtil.parseTwitterName(argMultimap.getValue(PREFIX_TWITTER))
+                    .ifPresent(editPersonDescriptor::setTwitterName);
+            ParserUtil.parseInstagramName(argMultimap.getValue(PREFIX_INSTAGRAM))
+                    .ifPresent(editPersonDescriptor::setInstagramName);
             ParserUtil.parseDisplayPic(argMultimap.getValue(PREFIX_DP)).ifPresent(editPersonDescriptor::setDisplayPic);
             parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editPersonDescriptor::setTags);
         } catch (IllegalValueException ive) {

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -16,6 +16,7 @@ import seedu.address.model.person.DisplayPic;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Phone;
+import seedu.address.model.person.UserName;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -88,6 +89,27 @@ public class ParserUtil {
     public static Optional<Birthday> parseBirthday(Optional<String> birthday) throws IllegalValueException {
         requireNonNull(birthday);
         return birthday.isPresent() ? Optional.of(new Birthday(birthday.get())) : Optional.empty();
+    }
+
+    /**
+     * Parses a {@code Optional<String> twitterUserName} into an {@code Optional<UserName>} if {@code twitterUserName}
+     * is present.
+     * See header comment of this class regarding the use of {@code Optional} parameters.
+     */
+    public static Optional<UserName> parseTwitterName(Optional<String> twitterUserName) throws IllegalValueException {
+        requireNonNull(twitterUserName);
+        return twitterUserName.isPresent() ? Optional.of(new UserName(twitterUserName.get())) : Optional.empty();
+    }
+
+    /**
+     * Parses a {@code Optional<String> twitterUserName} into an {@code Optional<UserName>} if {@code twitterUserName}
+     * is present.
+     * See header comment of this class regarding the use of {@code Optional} parameters.
+     */
+    public static Optional<UserName> parseInstagramName(Optional<String> instagramUserName)
+            throws IllegalValueException {
+        requireNonNull(instagramUserName);
+        return instagramUserName.isPresent() ? Optional.of(new UserName(instagramUserName.get())) : Optional.empty();
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -151,6 +151,10 @@ public class Person implements ReadOnlyPerson, Comparator<Person> {
         return twitterName.get();
     }
 
+    public void setTwitterName(UserName twitterName) {
+        this.twitterName.set(requireNonNull(twitterName));
+    }
+
     @Override
     public ObjectProperty<UserName> instagramNameProperty() {
         return instagramName;
@@ -159,6 +163,10 @@ public class Person implements ReadOnlyPerson, Comparator<Person> {
     @Override
     public UserName getInstagramName() {
         return instagramName.get();
+    }
+
+    public void setInstagramName(UserName instagramName) {
+        this.instagramName.set(requireNonNull(instagramName));
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -24,6 +24,8 @@ public class Person implements ReadOnlyPerson, Comparator<Person> {
     private ObjectProperty<Email> email;
     private ObjectProperty<Address> address;
     private ObjectProperty<Birthday> birthday;
+    private ObjectProperty<UserName> twitterName;
+    private ObjectProperty<UserName> instagramName;
     private ObjectProperty<DisplayPic> displayPic;
 
     private ObjectProperty<UniqueTagList> tags;
@@ -31,8 +33,8 @@ public class Person implements ReadOnlyPerson, Comparator<Person> {
     /**
      * Every field must be present and not null.
      */
-    public Person(Name name, Phone phone, Email email, Address address, Birthday birthday,
-                  DisplayPic displayPic, Set<Tag> tags) {
+    public Person(Name name, Phone phone, Email email, Address address, Birthday birthday, UserName twitterName,
+                  UserName instagramName, DisplayPic displayPic, Set<Tag> tags) {
         requireAllNonNull(name, phone, email, address, birthday, tags);
 
         this.name = new SimpleObjectProperty<>(name);
@@ -40,6 +42,8 @@ public class Person implements ReadOnlyPerson, Comparator<Person> {
         this.email = new SimpleObjectProperty<>(email);
         this.address = new SimpleObjectProperty<>(address);
         this.birthday = new SimpleObjectProperty<>(birthday);
+        this.twitterName = new SimpleObjectProperty<>(twitterName);
+        this.instagramName = new SimpleObjectProperty<>(instagramName);
         this.displayPic = new SimpleObjectProperty<>(displayPic);
         // protect internal tags from changes in the arg list
         this.tags = new SimpleObjectProperty<>(new UniqueTagList(tags));
@@ -50,7 +54,7 @@ public class Person implements ReadOnlyPerson, Comparator<Person> {
      */
     public Person(ReadOnlyPerson source) {
         this(source.getName(), source.getPhone(), source.getEmail(), source.getAddress(), source.getBirthday(),
-                source.getDisplayPic(), source.getTags());
+                source.getTwitterName(), source.getInstagramName(), source.getDisplayPic(), source.getTags());
     }
 
     public void setName(Name name) {
@@ -135,6 +139,26 @@ public class Person implements ReadOnlyPerson, Comparator<Person> {
     @Override
     public DisplayPic getDisplayPic() {
         return displayPic.get();
+    }
+
+    @Override
+    public ObjectProperty<UserName> twitterNameProperty() {
+        return twitterName;
+    }
+
+    @Override
+    public UserName getTwitterName() {
+        return twitterName.get();
+    }
+
+    @Override
+    public ObjectProperty<UserName> instagramNameProperty() {
+        return instagramName;
+    }
+
+    @Override
+    public UserName getInstagramName() {
+        return instagramName.get();
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/ReadOnlyPerson.java
+++ b/src/main/java/seedu/address/model/person/ReadOnlyPerson.java
@@ -24,7 +24,10 @@ public interface ReadOnlyPerson {
     Birthday getBirthday();
     ObjectProperty<DisplayPic> displayPicProperty();
     DisplayPic getDisplayPic();
-
+    ObjectProperty<UserName> twitterNameProperty();
+    UserName getTwitterName();
+    ObjectProperty<UserName> instagramNameProperty();
+    UserName getInstagramName();
     ObjectProperty<UniqueTagList> tagProperty();
     Set<Tag> getTags();
 
@@ -39,7 +42,9 @@ public interface ReadOnlyPerson {
                 && other.getEmail().equals(this.getEmail())
                 && other.getAddress().equals(this.getAddress()))
                 && other.getBirthday().equals(this.getBirthday())
-                && other.getDisplayPic().equals(this.getDisplayPic());
+                && other.getDisplayPic().equals(this.getDisplayPic())
+                && other.getTwitterName().equals(this.getTwitterName())
+                && other.getInstagramName().equals(this.getInstagramName());
     }
 
     /**
@@ -56,6 +61,10 @@ public interface ReadOnlyPerson {
                 .append(getAddress())
                 .append(" Birthday: ")
                 .append(getBirthday())
+                .append(" Twitter: ")
+                .append(getTwitterName())
+                .append(" Instagram: ")
+                .append(getTwitterName())
                 .append(" DisplayPic Path: ")
                 .append(getDisplayPic())
                 .append(" Tags: ");

--- a/src/main/java/seedu/address/model/person/UserName.java
+++ b/src/main/java/seedu/address/model/person/UserName.java
@@ -11,7 +11,7 @@ import seedu.address.commons.exceptions.IllegalValueException;
 public class UserName {
 
     public static final String MESSAGE_USERNAME_CONSTRAINTS =
-            "Social media username should only contain alphanumeric characters.";
+            "Social media username should only contain alphanumeric characters and underscores.";
 
     /*
      * The first character of the username must not be a whitespace,

--- a/src/main/java/seedu/address/model/person/UserName.java
+++ b/src/main/java/seedu/address/model/person/UserName.java
@@ -20,7 +20,7 @@ public class UserName {
      */
     public static final String USERNAME_VALIDATION_REGEX = "\\w+";
 
-    public final String userName;
+    public final String value;
 
     /**
      * Validates given username.
@@ -33,7 +33,7 @@ public class UserName {
         if (trimmedUserName.length() != 0 && !isValidUserName(trimmedUserName)) {
             throw new IllegalValueException(MESSAGE_USERNAME_CONSTRAINTS);
         }
-        this.userName = trimmedUserName;
+        this.value = trimmedUserName;
     }
 
     /**
@@ -45,19 +45,19 @@ public class UserName {
 
     @Override
     public String toString() {
-        return userName;
+        return value;
     }
 
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof UserName // instanceof handles nulls
-                && this.userName.equals(((UserName) other).userName)); // state check
+                && this.value.equals(((UserName) other).value)); // state check
     }
 
     @Override
     public int hashCode() {
-        return userName.hashCode();
+        return value.hashCode();
     }
 
 }

--- a/src/main/java/seedu/address/model/person/UserName.java
+++ b/src/main/java/seedu/address/model/person/UserName.java
@@ -1,0 +1,63 @@
+package seedu.address.model.person;
+
+import static java.util.Objects.requireNonNull;
+
+import seedu.address.commons.exceptions.IllegalValueException;
+
+/**
+ * Represents a Person's social media username in the address book.
+ * Guarantees: immutable; is valid as declared in {@link #isValidUserName(String)}
+ */
+public class UserName {
+
+    public static final String MESSAGE_USERNAME_CONSTRAINTS =
+            "Social media username should only contain alphanumeric characters.";
+
+    /*
+     * The first character of the username must not be a whitespace,
+     * otherwise " " (a blank string) becomes a valid input.
+     * It should only contain alphanumeric characters.
+     */
+    public static final String USERNAME_VALIDATION_REGEX = "\\w+";
+
+    public final String userName;
+
+    /**
+     * Validates given username.
+     *
+     * @throws IllegalValueException if given username string is invalid.
+     */
+    public UserName(String name) throws IllegalValueException {
+        requireNonNull(name);
+        String trimmedUserName = name.trim();
+        if (trimmedUserName.length() != 0 && !isValidUserName(trimmedUserName)) {
+            throw new IllegalValueException(MESSAGE_USERNAME_CONSTRAINTS);
+        }
+        this.userName = trimmedUserName;
+    }
+
+    /**
+     * Returns true if a given string is a valid social media username.
+     */
+    public static boolean isValidUserName(String test) {
+        return test.matches(USERNAME_VALIDATION_REGEX);
+    }
+
+    @Override
+    public String toString() {
+        return userName;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof UserName // instanceof handles nulls
+                && this.userName.equals(((UserName) other).userName)); // state check
+    }
+
+    @Override
+    public int hashCode() {
+        return userName.hashCode();
+    }
+
+}

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -15,6 +15,7 @@ import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
+import seedu.address.model.person.UserName;
 import seedu.address.model.person.exceptions.DuplicatePersonException;
 import seedu.address.model.tag.Tag;
 
@@ -27,21 +28,27 @@ public class SampleDataUtil {
             return new Person[] {
                 new Person(new Name("Alex Yeoh"), new Phone("87438807"), new Email("alexyeoh@example.com"),
                     new Address("Blk 30 Geylang Street 29, #06-40"), new Birthday("03/01/1993"),
+                    new UserName("alexyeoh"), new UserName("alexyeoh"),
                     new DisplayPic(DEFAULT_DISPLAY_PIC), getTagSet("friends")),
                 new Person(new Name("Bernice Yu"), new Phone("99272758"), new Email("berniceyu@example.com"),
                     new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"), new Birthday("02/04/1994"),
+                        new UserName("94yubernice"), new UserName("yubernice94"),
                     new DisplayPic(DEFAULT_DISPLAY_PIC), getTagSet("colleagues", "friends")),
                 new Person(new Name("Charlotte Oliveiro"), new Phone("93210283"), new Email("charlotte@example.com"),
                     new Address("Blk 11 Ang Mo Kio Street 74, #11-04"), new Birthday("14/07/1990"),
+                        new UserName("oliverio14"), new UserName("oliverio14"),
                     new DisplayPic(DEFAULT_DISPLAY_PIC), getTagSet("neighbours")),
                 new Person(new Name("David Li"), new Phone("91031282"), new Email("lidavid@example.com"),
                     new Address("Blk 436 Serangoon Gardens Street 26, #16-43"), new Birthday("16/10/1985"),
-                    new DisplayPic(DEFAULT_DISPLAY_PIC), getTagSet("family")),
+                        new UserName("oliverio14"), new UserName("oliverio14"),
+                        new DisplayPic(DEFAULT_DISPLAY_PIC), getTagSet("family")),
                 new Person(new Name("Irfan Ibrahim"), new Phone("92492021"), new Email("irfan@example.com"),
                     new Address("Blk 47 Tampines Street 20, #17-35"), new Birthday("10/11/1984"),
+                        new UserName("irfanIB"), new UserName("irfanIB"),
                     new DisplayPic(DEFAULT_DISPLAY_PIC), getTagSet("classmates")),
                 new Person(new Name("Roy Balakrishnan"), new Phone("92624417"), new Email("royb@example.com"),
                     new Address("Blk 45 Aljunied Street 85, #11-31"), new Birthday("20/06/1990"),
+                        new UserName("Roy_90"), new UserName("Roy_90"),
                     new DisplayPic(DEFAULT_DISPLAY_PIC), getTagSet("colleagues"))
             };
         } catch (IllegalValueException e) {

--- a/src/main/java/seedu/address/storage/XmlAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/XmlAdaptedPerson.java
@@ -33,9 +33,9 @@ public class XmlAdaptedPerson {
     @XmlElement(required = true)
     private String address;
     @XmlElement(required = true)
-    private String twitterUserName;
+    private String twitterName;
     @XmlElement(required = true)
-    private String instagramUserName;
+    private String instagramName;
     @XmlElement(required = true)
     private String birthday;
     @XmlElement(required = true)
@@ -62,8 +62,8 @@ public class XmlAdaptedPerson {
         email = source.getEmail().value;
         address = source.getAddress().value;
         birthday = source.getBirthday().value;
-        twitterUserName = source.getTwitterName().value;
-        instagramUserName = source.getInstagramName().value;
+        twitterName = source.getTwitterName().value;
+        instagramName = source.getInstagramName().value;
         displayPicPath = source.getDisplayPic().displayPicPath;
         tagged = new ArrayList<>();
         for (Tag tag : source.getTags()) {
@@ -86,12 +86,12 @@ public class XmlAdaptedPerson {
         final Email email = new Email(this.email);
         final Address address = new Address(this.address);
         final Birthday birthday = new Birthday(this.birthday);
-        final UserName twitterUserName = new UserName(this.twitterUserName);
-        final UserName instagramUserName = new UserName(this.instagramUserName);
+        final UserName twitterName = new UserName(this.twitterName);
+        final UserName instagramName = new UserName(this.instagramName);
         final DisplayPic displayPic = new DisplayPic(this.displayPicPath);
         final Set<Tag> tags = new HashSet<>(personTags);
-        return new Person(name, phone, email, address, birthday, twitterUserName,
-                instagramUserName, displayPic, tags);
+        return new Person(name, phone, email, address, birthday, twitterName,
+                instagramName, displayPic, tags);
 
     }
 }

--- a/src/main/java/seedu/address/storage/XmlAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/XmlAdaptedPerson.java
@@ -16,6 +16,7 @@ import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
 import seedu.address.model.person.ReadOnlyPerson;
+import seedu.address.model.person.UserName;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -31,6 +32,10 @@ public class XmlAdaptedPerson {
     private String email;
     @XmlElement(required = true)
     private String address;
+    @XmlElement(required = true)
+    private String twitterUserName;
+    @XmlElement(required = true)
+    private String instagramUserName;
     @XmlElement(required = true)
     private String birthday;
     @XmlElement(required = true)
@@ -57,6 +62,8 @@ public class XmlAdaptedPerson {
         email = source.getEmail().value;
         address = source.getAddress().value;
         birthday = source.getBirthday().value;
+        twitterUserName = source.getTwitterName().value;
+        instagramUserName = source.getInstagramName().value;
         displayPicPath = source.getDisplayPic().displayPicPath;
         tagged = new ArrayList<>();
         for (Tag tag : source.getTags()) {
@@ -79,9 +86,12 @@ public class XmlAdaptedPerson {
         final Email email = new Email(this.email);
         final Address address = new Address(this.address);
         final Birthday birthday = new Birthday(this.birthday);
+        final UserName twitterUserName = new UserName(this.twitterUserName);
+        final UserName instagramUserName = new UserName(this.instagramUserName);
         final DisplayPic displayPic = new DisplayPic(this.displayPicPath);
         final Set<Tag> tags = new HashSet<>(personTags);
-        return new Person(name, phone, email, address, birthday, displayPic, tags);
+        return new Person(name, phone, email, address, birthday, twitterUserName,
+                instagramUserName, displayPic, tags);
 
     }
 }

--- a/src/test/data/XmlUtilTest/validAddressBook.xml
+++ b/src/test/data/XmlUtilTest/validAddressBook.xml
@@ -6,6 +6,8 @@
         <email isPrivate="false">hans@example.com</email>
         <address isPrivate="false">4th street</address>
         <birthday isPrivate="false">20/08/1991</birthday>
+        <twitterName isPrivate="false">muster_91</twitterName>
+        <instagramName isPrivate="false"></instagramName>
         <displayPicPath>/Users/JunQuan/Desktop/CS2103/AB4-main/data/images/defaultperson.png</displayPicPath>
     </persons>
     <persons>
@@ -14,6 +16,8 @@
         <email isPrivate="false">ruth@example.com</email>
         <address isPrivate="false">81th street</address>
         <birthday isPrivate="false">15/04/1899</birthday>
+        <twitterName isPrivate="false">mueller_ruth</twitterName>
+        <instagramName isPrivate="false">ruth_mueller</instagramName>
         <displayPicPath>/Users/JunQuan/Desktop/CS2103/AB4-main/data/images/defaultperson.png</displayPicPath>
     </persons>
     <persons>
@@ -22,6 +26,8 @@
         <email isPrivate="false">heinz@example.com</email>
         <address isPrivate="false">wall street</address>
         <birthday isPrivate="false">22/12/1990</birthday>
+        <twitterName isPrivate="false">heinz</twitterName>
+        <instagramName isPrivate="false">heinz_kurz</instagramName>
         <displayPicPath>/Users/JunQuan/Desktop/CS2103/AB4-main/data/images/defaultperson.png</displayPicPath>
     </persons>
     <persons>
@@ -30,6 +36,8 @@
         <email isPrivate="false">cornelia@example.com</email>
         <address isPrivate="false">10th street</address>
         <birthday isPrivate="false">03/11/1997</birthday>
+        <twitterName isPrivate="false"></twitterName>
+        <instagramName isPrivate="false"></instagramName>
         <displayPicPath>/Users/JunQuan/Desktop/CS2103/AB4-main/data/images/defaultperson.png</displayPicPath>
     </persons>
     <persons>
@@ -38,6 +46,8 @@
         <email isPrivate="false">werner@example.com</email>
         <address isPrivate="false">michegan ave</address>
         <birthday isPrivate="false">19/05/1995</birthday>
+        <twitterName isPrivate="false"></twitterName>
+        <instagramName isPrivate="false"></instagramName>
         <displayPicPath>/Users/JunQuan/Desktop/CS2103/AB4-main/data/images/defaultperson.png</displayPicPath>
     </persons>
     <persons>
@@ -46,6 +56,8 @@
         <email isPrivate="false">lydia@example.com</email>
         <address isPrivate="false">little tokyo</address>
         <birthday isPrivate="false">11/02/1911</birthday>
+        <twitterName isPrivate="false"></twitterName>
+        <instagramName isPrivate="false"></instagramName>
         <displayPicPath>/Users/JunQuan/Desktop/CS2103/AB4-main/data/images/defaultperson.png</displayPicPath>
     </persons>
     <persons>
@@ -54,6 +66,8 @@
         <email isPrivate="false">anna@example.com</email>
         <address isPrivate="false">4th street</address>
         <birthday isPrivate="false">19/04/1959</birthday>
+        <twitterName isPrivate="false"></twitterName>
+        <instagramName isPrivate="false"></instagramName>
         <displayPicPath>/Users/JunQuan/Desktop/CS2103/AB4-main/data/images/defaultperson.png</displayPicPath>
     </persons>
     <persons>
@@ -62,6 +76,8 @@
         <email isPrivate="false">stefan@example.com</email>
         <address isPrivate="false">little india</address>
         <birthday isPrivate="false">16/06/1985</birthday>
+        <twitterName isPrivate="false"></twitterName>
+        <instagramName isPrivate="false"></instagramName>
         <displayPicPath>/Users/JunQuan/Desktop/CS2103/AB4-main/data/images/defaultperson.png</displayPicPath>
     </persons>
     <persons>
@@ -70,6 +86,8 @@
         <email isPrivate="false">hans@example.com</email>
         <address isPrivate="false">chicago ave</address>
         <birthday isPrivate="false">14/08/1980</birthday>
+        <twitterName isPrivate="false"></twitterName>
+        <instagramName isPrivate="false"></instagramName>
         <displayPicPath>/Users/JunQuan/Desktop/CS2103/AB4-main/data/images/defaultperson.png</displayPicPath>
     </persons>
 </addressbook>

--- a/src/test/java/seedu/address/commons/core/ConfigTest.java
+++ b/src/test/java/seedu/address/commons/core/ConfigTest.java
@@ -14,7 +14,7 @@ public class ConfigTest {
 
     @Test
     public void toString_defaultObject_stringReturned() {
-        String defaultConfigAsString = "App title : Address App\n"
+        String defaultConfigAsString = "App title : HitMeUp\n"
                 + "Current log level : INFO\n"
                 + "Preference file Location : preferences.json";
 

--- a/src/test/java/seedu/address/commons/util/GoogleUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/GoogleUtilTest.java
@@ -15,7 +15,8 @@ public class GoogleUtilTest {
     @Test
     public void convertFromGooglePerson_success() throws IllegalValueException {
         Person typicalPerson = new GooglePersonBuilder().build();
-        seedu.address.model.person.Person typicalAddressBookPerson = new PersonBuilder().withTags("Google").build();
+        seedu.address.model.person.Person typicalAddressBookPerson = new PersonBuilder().withTags("Google")
+                .withTwitter("").withInstagram("").build();
         assertEquals(typicalAddressBookPerson, GoogleUtil.convertPerson(typicalPerson));
 
     }

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -72,7 +72,8 @@ public class CommandTestUtil {
     public static final String INVALID_ADDRESS_DESC = " " + PREFIX_ADDRESS + ""; // empty string allowed for addresses
     public static final String INVALID_BIRTHDAY_DESC = " " + PREFIX_BIRTHDAY + "05.11.1990"; //only '/' allowed
     public static final String INVALID_TAG_DESC = " " + PREFIX_TAG + "hubby*"; // '*' not allowed in tags
-
+    public static final String INVALID_TWITTER_DESC = " " + PREFIX_TWITTER + "alice.pauline"; // '.' not allowed
+    public static final String INVALID_INSTAGRAM_DESC = " " + PREFIX_INSTAGRAM + "alice.pauline"; // '.' not allowed
     public static final EditCommand.EditPersonDescriptor DESC_AMY;
     public static final EditCommand.EditPersonDescriptor DESC_BOB;
 

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -6,9 +6,11 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_BIRTHDAY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DP;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_INSTAGRAM;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TWITTER;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -37,6 +39,10 @@ public class CommandTestUtil {
     public static final String VALID_ADDRESS_BOB = "Block 123, Bobby Street 3";
     public static final String VALID_BIRTHDAY_AMY = "11/07/1977";
     public static final String VALID_BIRTHDAY_BOB = "05/06/1994";
+    public static final String VALID_TWITTER_AMY = "amy_bee";
+    public static final String VALID_TWITTER_BOB = "choo_bob";
+    public static final String VALID_INSTAGRAM_AMY = "amy_bee";
+    public static final String VALID_INSTAGRAM_BOB = "choo_bob";
     public static final String VALID_DISPLAYPIC = "/images/defaultperson.png";
     public static final String VALID_TAG_HUSBAND = "husband";
     public static final String VALID_TAG_FRIEND = "friend";
@@ -51,6 +57,10 @@ public class CommandTestUtil {
     public static final String ADDRESS_DESC_BOB = " " + PREFIX_ADDRESS + VALID_ADDRESS_BOB;
     public static final String BIRTHDAY_DESC_AMY = " " + PREFIX_BIRTHDAY + VALID_BIRTHDAY_AMY;
     public static final String BIRTHDAY_DESC_BOB = " " + PREFIX_BIRTHDAY + VALID_BIRTHDAY_BOB;
+    public static final String TWITTER_DESC_AMY = " " + PREFIX_TWITTER + VALID_TWITTER_AMY;
+    public static final String TWITTER_DESC_BOB = " " + PREFIX_TWITTER + VALID_TWITTER_BOB;
+    public static final String INSTAGRAM_DESC_AMY = " " + PREFIX_INSTAGRAM + VALID_INSTAGRAM_AMY;
+    public static final String INSTAGRAM_DESC_BOB = " " + PREFIX_INSTAGRAM + VALID_INSTAGRAM_BOB;
     public static final String DISPLAYPIC_DESC = " " + PREFIX_DP + VALID_DISPLAYPIC;
     public static final String DISPLAYPIC_DEFAULT = " " + PREFIX_DP + "N";
     public static final String TAG_DESC_FRIEND = " " + PREFIX_TAG + VALID_TAG_FRIEND;

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -8,6 +8,8 @@ import static seedu.address.logic.commands.CommandTestUtil.BIRTHDAY_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.DISPLAYPIC_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.INSTAGRAM_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.INSTAGRAM_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_ADDRESS_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_BIRTHDAY_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_EMAIL_DESC;
@@ -20,6 +22,8 @@ import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_FRIEND;
 import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_HUSBAND;
+import static seedu.address.logic.commands.CommandTestUtil.TWITTER_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.TWITTER_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_BIRTHDAY_AMY;
@@ -27,12 +31,16 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_BIRTHDAY_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_DISPLAYPIC;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_INSTAGRAM_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_INSTAGRAM_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TWITTER_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TWITTER_BOB;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
@@ -54,39 +62,47 @@ public class AddCommandParserTest {
     public void parse_allFieldsPresent_success() {
         Person expectedPerson = new PersonBuilder().withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
                 .withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB).withBirthday(VALID_BIRTHDAY_BOB)
+                .withTwitter(VALID_TWITTER_BOB).withInstagram(VALID_INSTAGRAM_BOB)
                 .withDisplayPic(VALID_DISPLAYPIC).withTags(VALID_TAG_FRIEND).build();
 
         // multiple names - last name accepted
         assertParseSuccess(parser, AddCommand.COMMAND_WORD + NAME_DESC_AMY + NAME_DESC_BOB + PHONE_DESC_BOB
-                + EMAIL_DESC_BOB + ADDRESS_DESC_BOB + BIRTHDAY_DESC_BOB + DISPLAYPIC_DESC
+                + EMAIL_DESC_BOB + ADDRESS_DESC_BOB + BIRTHDAY_DESC_BOB  + TWITTER_DESC_BOB + INSTAGRAM_DESC_BOB
+                + DISPLAYPIC_DESC
                 + TAG_DESC_FRIEND, new AddCommand(expectedPerson));
 
         // multiple phones - last phone accepted
         assertParseSuccess(parser, AddCommand.COMMAND_WORD + NAME_DESC_BOB + PHONE_DESC_AMY + PHONE_DESC_BOB
-                + EMAIL_DESC_BOB + ADDRESS_DESC_BOB + BIRTHDAY_DESC_BOB + DISPLAYPIC_DESC
+                + EMAIL_DESC_BOB + ADDRESS_DESC_BOB + BIRTHDAY_DESC_BOB  + TWITTER_DESC_BOB + INSTAGRAM_DESC_BOB
+                + DISPLAYPIC_DESC
                 + TAG_DESC_FRIEND, new AddCommand(expectedPerson));
 
         // multiple emails - last email accepted
         assertParseSuccess(parser, AddCommand.COMMAND_WORD + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_AMY
-                + EMAIL_DESC_BOB + ADDRESS_DESC_BOB + BIRTHDAY_DESC_BOB + DISPLAYPIC_DESC
+                + EMAIL_DESC_BOB + ADDRESS_DESC_BOB + BIRTHDAY_DESC_BOB + TWITTER_DESC_BOB + INSTAGRAM_DESC_BOB
+                + DISPLAYPIC_DESC
                 + TAG_DESC_FRIEND, new AddCommand(expectedPerson));
 
         // multiple addresses - last address accepted
         assertParseSuccess(parser, AddCommand.COMMAND_WORD + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                + ADDRESS_DESC_AMY + ADDRESS_DESC_BOB + BIRTHDAY_DESC_BOB + DISPLAYPIC_DESC
+                + ADDRESS_DESC_AMY + ADDRESS_DESC_BOB + BIRTHDAY_DESC_BOB + TWITTER_DESC_BOB + INSTAGRAM_DESC_BOB
+                + DISPLAYPIC_DESC
                 + TAG_DESC_FRIEND, new AddCommand(expectedPerson));
 
         // multiple birthdays - last birthday accepted
         assertParseSuccess(parser, AddCommand.COMMAND_WORD + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                + ADDRESS_DESC_BOB + BIRTHDAY_DESC_AMY + BIRTHDAY_DESC_BOB + DISPLAYPIC_DESC
+                + ADDRESS_DESC_BOB + BIRTHDAY_DESC_AMY + BIRTHDAY_DESC_BOB + TWITTER_DESC_BOB + INSTAGRAM_DESC_BOB
+                + DISPLAYPIC_DESC
                 + TAG_DESC_FRIEND, new AddCommand(expectedPerson));
 
         // multiple tags - all accepted
         Person expectedPersonMultipleTags = new PersonBuilder().withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
                 .withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB).withBirthday(VALID_BIRTHDAY_BOB)
+                .withTwitter(VALID_TWITTER_BOB).withInstagram(VALID_INSTAGRAM_BOB)
                 .withDisplayPic(VALID_DISPLAYPIC).withTags(VALID_TAG_FRIEND, VALID_TAG_HUSBAND).build();
         assertParseSuccess(parser, AddCommand.COMMAND_WORD + NAME_DESC_BOB + PHONE_DESC_BOB
-                        + EMAIL_DESC_BOB + ADDRESS_DESC_BOB + BIRTHDAY_DESC_BOB + DISPLAYPIC_DESC + TAG_DESC_HUSBAND
+                        + EMAIL_DESC_BOB + ADDRESS_DESC_BOB + BIRTHDAY_DESC_BOB + TWITTER_DESC_BOB + INSTAGRAM_DESC_BOB
+                        + DISPLAYPIC_DESC + TAG_DESC_HUSBAND
                         + TAG_DESC_FRIEND, new AddCommand(expectedPersonMultipleTags));
     }
 
@@ -95,34 +111,42 @@ public class AddCommandParserTest {
         // zero tags
         Person expectedPerson = new PersonBuilder().withName(VALID_NAME_AMY).withPhone(VALID_PHONE_AMY)
                 .withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY).withBirthday(VALID_BIRTHDAY_AMY)
+                .withTwitter(VALID_TWITTER_AMY).withInstagram(VALID_INSTAGRAM_AMY)
                 .withDisplayPic(VALID_DISPLAYPIC).withTags().build();
         assertParseSuccess(parser, AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY
-                + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + BIRTHDAY_DESC_AMY + DISPLAYPIC_DESC,
+                + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + BIRTHDAY_DESC_AMY + TWITTER_DESC_AMY + INSTAGRAM_DESC_AMY
+                        + DISPLAYPIC_DESC,
                 new AddCommand(expectedPerson));
 
         // no email
         expectedPerson = new PersonBuilder().withName(VALID_NAME_AMY).withPhone(VALID_PHONE_AMY)
                 .withEmail("").withAddress(VALID_ADDRESS_AMY).withBirthday(VALID_BIRTHDAY_AMY)
+                .withTwitter(VALID_TWITTER_AMY).withInstagram(VALID_INSTAGRAM_AMY)
                 .withDisplayPic(VALID_DISPLAYPIC).withTags().build();
 
         assertParseSuccess(parser, AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY
-            + ADDRESS_DESC_AMY + BIRTHDAY_DESC_AMY + DISPLAYPIC_DESC, new AddCommand(expectedPerson));
+            + ADDRESS_DESC_AMY + BIRTHDAY_DESC_AMY  + TWITTER_DESC_AMY + INSTAGRAM_DESC_AMY
+                + DISPLAYPIC_DESC, new AddCommand(expectedPerson));
 
         // no address
         expectedPerson = new PersonBuilder().withName(VALID_NAME_AMY).withPhone(VALID_PHONE_AMY)
                 .withEmail(VALID_EMAIL_AMY).withAddress("").withBirthday(VALID_BIRTHDAY_AMY)
+                .withTwitter(VALID_TWITTER_AMY).withInstagram(VALID_INSTAGRAM_AMY)
                 .withDisplayPic(VALID_DISPLAYPIC).withTags().build();
 
         assertParseSuccess(parser, AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY
-            + EMAIL_DESC_AMY + BIRTHDAY_DESC_AMY + DISPLAYPIC_DESC, new AddCommand(expectedPerson));
+            + EMAIL_DESC_AMY + BIRTHDAY_DESC_AMY  + TWITTER_DESC_AMY + INSTAGRAM_DESC_AMY
+                + DISPLAYPIC_DESC, new AddCommand(expectedPerson));
 
         // no birthday
         expectedPerson = new PersonBuilder().withName(VALID_NAME_AMY).withPhone(VALID_PHONE_AMY)
                 .withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY).withBirthday("")
+                .withTwitter(VALID_TWITTER_AMY).withInstagram(VALID_INSTAGRAM_AMY)
                 .withDisplayPic(VALID_DISPLAYPIC).withTags().build();
 
         assertParseSuccess(parser, AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY
-                + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + DISPLAYPIC_DESC, new AddCommand(expectedPerson));
+                + EMAIL_DESC_AMY + TWITTER_DESC_AMY + INSTAGRAM_DESC_AMY
+                + ADDRESS_DESC_AMY + DISPLAYPIC_DESC, new AddCommand(expectedPerson));
 
     }
 

--- a/src/test/java/seedu/address/testutil/EditPersonDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/EditPersonDescriptorBuilder.java
@@ -33,6 +33,8 @@ public class EditPersonDescriptorBuilder {
         descriptor.setEmail(person.getEmail());
         descriptor.setAddress(person.getAddress());
         descriptor.setBirthday(person.getBirthday());
+        descriptor.setTwitterName(person.getTwitterName());
+        descriptor.setInstagramName(person.getInstagramName());
         descriptor.setDisplayPic(person.getDisplayPic());
         descriptor.setTags(person.getTags());
     }

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -11,6 +11,7 @@ import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
 import seedu.address.model.person.ReadOnlyPerson;
+import seedu.address.model.person.UserName;
 import seedu.address.model.tag.Tag;
 import seedu.address.model.util.SampleDataUtil;
 
@@ -24,6 +25,8 @@ public class PersonBuilder {
     public static final String DEFAULT_EMAIL = "alice@gmail.com";
     public static final String DEFAULT_ADDRESS = "123, Jurong West Ave 6, #08-111";
     public static final String DEFAULT_BIRTHDAY = "03/07/1990";
+    public static final String DEFAULT_TWITTER = "alice_pauline";
+    public static final String DEFAULT_INSTAGRAM = "alice_pauline";
     public static final String DEFAULT_DISPLAYPIC = "/images/defaultperson.png";
     public static final String DEFAULT_TAGS = "friends";
 
@@ -36,10 +39,12 @@ public class PersonBuilder {
             Email defaultEmail = new Email(DEFAULT_EMAIL);
             Address defaultAddress = new Address(DEFAULT_ADDRESS);
             Birthday defaultBirthday = new Birthday(DEFAULT_BIRTHDAY);
+            UserName defaultTwitter = new UserName(DEFAULT_TWITTER);
+            UserName defaultInstagram = new UserName(DEFAULT_INSTAGRAM);
             DisplayPic defaultDisplayPic = new DisplayPic(DEFAULT_DISPLAYPIC);
             Set<Tag> defaultTags = SampleDataUtil.getTagSet(DEFAULT_TAGS);
             this.person = new Person(defaultName, defaultPhone, defaultEmail, defaultAddress, defaultBirthday,
-                    defaultDisplayPic, defaultTags);
+                    defaultTwitter, defaultInstagram, defaultDisplayPic, defaultTags);
         } catch (IllegalValueException ive) {
             throw new AssertionError("Default person's values are invalid.");
         }
@@ -132,6 +137,30 @@ public class PersonBuilder {
             this.person.setBirthday(new Birthday(birthday));
         } catch (IllegalValueException ive) {
             throw new IllegalArgumentException("birthday is expected to be unique.");
+        }
+        return this;
+    }
+
+    /**
+     * Sets the Twitter {@code UserName} of the {@code Person} that we are building.
+     */
+    public PersonBuilder withTwitter(String twitterUser) {
+        try {
+            this.person.setTwitterName(new UserName(twitterUser));
+        } catch (IllegalValueException ive) {
+            throw new IllegalArgumentException("twitter username is expected to be unique.");
+        }
+        return this;
+    }
+
+    /**
+     * Sets the Instagram {@code UserName} of the {@code Person} that we are building.
+     */
+    public PersonBuilder withInstagram(String instagramUser) {
+        try {
+            this.person.setInstagramName(new UserName(instagramUser));
+        } catch (IllegalValueException ive) {
+            throw new IllegalArgumentException("instagram username is expected to be unique.");
         }
         return this;
     }

--- a/src/test/java/seedu/address/testutil/PersonUtil.java
+++ b/src/test/java/seedu/address/testutil/PersonUtil.java
@@ -4,9 +4,11 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_BIRTHDAY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DP;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_INSTAGRAM;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TWITTER;
 
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.model.person.ReadOnlyPerson;
@@ -40,6 +42,8 @@ public class PersonUtil {
         sb.append(PREFIX_EMAIL + person.getEmail().value + " ");
         sb.append(PREFIX_ADDRESS + person.getAddress().value + " ");
         sb.append(PREFIX_BIRTHDAY + person.getBirthday().value + " ");
+        sb.append(PREFIX_TWITTER + person.getTwitterName().value + " ");
+        sb.append(PREFIX_INSTAGRAM + person.getInstagramName().value + " ");
         sb.append(PREFIX_DP + person.getDisplayPic().toString() + " ");
         person.getTags().stream().forEach(
             s -> sb.append(PREFIX_TAG + s.tagName + " ")
@@ -54,6 +58,8 @@ public class PersonUtil {
         sb.append(PREFIX_EMAIL + person.getEmail().value + " ");
         sb.append(PREFIX_ADDRESS + person.getAddress().value + " ");
         sb.append(PREFIX_BIRTHDAY + person.getBirthday().value + " ");
+        sb.append(PREFIX_TWITTER + person.getTwitterName().value + " ");
+        sb.append(PREFIX_INSTAGRAM + person.getInstagramName().value + " ");
         sb.append(PREFIX_DP + "N ");
         person.getTags().stream().forEach(
             s -> sb.append(PREFIX_TAG + s.tagName + " ")

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -7,12 +7,16 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_BIRTHDAY_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_DISPLAYPIC;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_INSTAGRAM_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_INSTAGRAM_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TWITTER_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TWITTER_BOB;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -34,37 +38,47 @@ public class TypicalPersons {
     public static final ReadOnlyPerson BENSON = new PersonBuilder().withName("Benson Meier")
             .withAddress("311, Clementi Ave 2, #02-25")
             .withEmail("johnd@example.com").withPhone("98765432").withBirthday("03/07/1886")
+            .withTwitter("meier").withInstagram("meier")
             .withDisplayPic("/images/defaultperson.png").withTags("owesMoney", "friends").build();
     public static final ReadOnlyPerson CARL = new PersonBuilder().withName("Carl Kurz").withPhone("95352563")
             .withEmail("heinz@example.com").withAddress("wall street").withBirthday("05/05/1997")
+            .withTwitter("kurz").withInstagram("kurz")
             .withDisplayPic("/images/defaultperson.png").build();
     public static final ReadOnlyPerson DANIEL = new PersonBuilder().withName("Daniel Meier").withPhone("87652533")
             .withEmail("cornelia@example.com").withAddress("10th street").withBirthday("03/03/1993")
+            .withTwitter("meier_dan").withInstagram("meier_dan")
             .withDisplayPic("/images/defaultperson.png").build();
     public static final ReadOnlyPerson ELLE = new PersonBuilder().withName("Elle Meyer").withPhone("9482224")
             .withEmail("werner@example.com").withAddress("michegan ave").withBirthday("06/12/1993")
+            .withTwitter("meyer_elle").withInstagram("meyer_elle")
             .withDisplayPic("/images/defaultperson.png").build();
     public static final ReadOnlyPerson FIONA = new PersonBuilder().withName("Fiona Kunz").withPhone("9482427")
             .withEmail("lydia@example.com").withAddress("little tokyo").withBirthday("04/11/1955")
+            .withTwitter("kunz").withInstagram("kunz")
             .withDisplayPic("/images/defaultperson.png").build();
     public static final ReadOnlyPerson GEORGE = new PersonBuilder().withName("George Best").withPhone("9482442")
             .withEmail("anna@example.com").withAddress("4th street").withBirthday("08/09/1969")
+            .withTwitter("iamthebest").withInstagram("iamthebest")
             .withDisplayPic("/images/defaultperson.png").build();
 
     // Manually added
     public static final ReadOnlyPerson HOON = new PersonBuilder().withName("Hoon Meier").withPhone("8482424")
             .withEmail("stefan@example.com").withAddress("little india").withBirthday("27/10/1899")
+            .withTwitter("meier_hoon").withInstagram("meier_hoon")
             .withDisplayPic("/images/defaultperson.png").build();
     public static final ReadOnlyPerson IDA = new PersonBuilder().withName("Ida Mueller").withPhone("8482131")
             .withEmail("hans@example.com").withAddress("chicago ave").withBirthday("16/12/1990")
+            .withTwitter("ida_mueller").withInstagram("ida_mueller")
             .withDisplayPic("/images/defaultperson.png").build();
 
     // Manually added - Person's details found in {@code CommandTestUtil}
     public static final ReadOnlyPerson AMY = new PersonBuilder().withName(VALID_NAME_AMY).withPhone(VALID_PHONE_AMY)
             .withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY).withBirthday(VALID_BIRTHDAY_AMY)
+            .withTwitter(VALID_TWITTER_AMY).withInstagram(VALID_INSTAGRAM_AMY)
             .withDisplayPic(VALID_DISPLAYPIC).withTags(VALID_TAG_FRIEND).build();
     public static final ReadOnlyPerson BOB = new PersonBuilder().withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
             .withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB).withBirthday(VALID_BIRTHDAY_BOB)
+            .withTwitter(VALID_TWITTER_BOB).withInstagram(VALID_INSTAGRAM_BOB)
             .withDisplayPic(VALID_DISPLAYPIC).withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).build();
 
     public static final String KEYWORD_MATCHING_MEIER = "Meier"; // A keyword that matches MEIER

--- a/src/test/java/systemtests/AddCommandSystemTest.java
+++ b/src/test/java/systemtests/AddCommandSystemTest.java
@@ -13,9 +13,11 @@ import static seedu.address.logic.commands.CommandTestUtil.INSTAGRAM_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_ADDRESS_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_BIRTHDAY_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_EMAIL_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_INSTAGRAM_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_PHONE_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_TAG_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_TWITTER_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
@@ -62,6 +64,7 @@ import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Phone;
 import seedu.address.model.person.ReadOnlyPerson;
+import seedu.address.model.person.UserName;
 import seedu.address.model.person.exceptions.DuplicatePersonException;
 import seedu.address.model.tag.Tag;
 import seedu.address.testutil.PersonBuilder;
@@ -175,6 +178,24 @@ public class AddCommandSystemTest extends AddressBookSystemTest {
                 + TWITTER_DESC_AMY + INSTAGRAM_DESC_AMY + DISPLAYPIC_DEFAULT + TAG_DESC_FRIEND;
         assertCommandSuccess(command, toAdd);
 
+        /* Case: no twitter username -> added */
+        toAdd = new PersonBuilder().withName(VALID_NAME_AMY).withPhone(VALID_PHONE_AMY).withEmail(VALID_EMAIL_AMY)
+                .withAddress(VALID_ADDRESS_AMY).withBirthday(VALID_BIRTHDAY_AMY).withTwitter("")
+                .withInstagram(VALID_INSTAGRAM_AMY)
+                .withDisplayPic(VALID_DISPLAYPIC).withTags(VALID_TAG_FRIEND).build();
+        command = AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY
+                + BIRTHDAY_DESC_AMY + INSTAGRAM_DESC_AMY + DISPLAYPIC_DEFAULT + TAG_DESC_FRIEND;
+        assertCommandSuccess(command, toAdd);
+
+        /* Case: no instagram username -> added */
+        toAdd = new PersonBuilder().withName(VALID_NAME_AMY).withPhone(VALID_PHONE_AMY).withEmail(VALID_EMAIL_AMY)
+                .withAddress(VALID_ADDRESS_AMY).withBirthday(VALID_BIRTHDAY_AMY).withTwitter(VALID_TWITTER_AMY)
+                .withInstagram("")
+                .withDisplayPic(VALID_DISPLAYPIC).withTags(VALID_TAG_FRIEND).build();
+        command = AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY
+                + BIRTHDAY_DESC_AMY + TWITTER_DESC_AMY + DISPLAYPIC_DEFAULT + TAG_DESC_FRIEND;
+        assertCommandSuccess(command, toAdd);
+
         /* Case: filters the person list before adding -> added */
         executeCommand(FindCommand.COMMAND_WORD + " " + KEYWORD_MATCHING_MEIER);
         assert getModel().getFilteredPersonList().size()
@@ -235,6 +256,19 @@ public class AddCommandSystemTest extends AddressBookSystemTest {
                 + INSTAGRAM_DESC_AMY + TWITTER_DESC_AMY
                 + INVALID_BIRTHDAY_DESC + DISPLAYPIC_DEFAULT;
         assertCommandFailure(command, Birthday.MESSAGE_BIRTHDAY_CONSTRAINTS);
+
+        /* Case: invalid twitter username -> rejected */
+        command = AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY
+                + INSTAGRAM_DESC_AMY + INVALID_TWITTER_DESC
+                + BIRTHDAY_DESC_AMY + DISPLAYPIC_DEFAULT;
+        assertCommandFailure(command, UserName.MESSAGE_USERNAME_CONSTRAINTS);
+
+        /* Case: invalid instagram username -> rejected */
+        command = AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY
+                + INVALID_INSTAGRAM_DESC + TWITTER_DESC_AMY
+                + BIRTHDAY_DESC_AMY + DISPLAYPIC_DEFAULT;
+        assertCommandFailure(command, UserName.MESSAGE_USERNAME_CONSTRAINTS);
+
 
         /* Case: invalid tag -> rejected */
         command = AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY

--- a/src/test/java/systemtests/AddCommandSystemTest.java
+++ b/src/test/java/systemtests/AddCommandSystemTest.java
@@ -8,6 +8,8 @@ import static seedu.address.logic.commands.CommandTestUtil.BIRTHDAY_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.DISPLAYPIC_DEFAULT;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.INSTAGRAM_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.INSTAGRAM_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_ADDRESS_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_BIRTHDAY_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_EMAIL_DESC;
@@ -20,6 +22,8 @@ import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_FRIEND;
 import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_HUSBAND;
+import static seedu.address.logic.commands.CommandTestUtil.TWITTER_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.TWITTER_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_BIRTHDAY_AMY;
@@ -27,11 +31,13 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_BIRTHDAY_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_DISPLAYPIC;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_INSTAGRAM_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TWITTER_AMY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.testutil.TypicalPersons.ALICE;
 import static seedu.address.testutil.TypicalPersons.AMY;
@@ -70,9 +76,9 @@ public class AddCommandSystemTest extends AddressBookSystemTest {
          * -> added
          */
         ReadOnlyPerson toAdd = AMY;
-        String command = "   " + AddCommand.COMMAND_WORD + "  " + NAME_DESC_AMY + "  " + PHONE_DESC_AMY + " "
-                + EMAIL_DESC_AMY + "   " + ADDRESS_DESC_AMY + " " + BIRTHDAY_DESC_AMY + "  "
-                + DISPLAYPIC_DEFAULT + " " + TAG_DESC_FRIEND + " ";
+        String command = "   " + AddCommand.COMMAND_WORD + "  " + NAME_DESC_AMY + "  " + PHONE_DESC_AMY
+                + " " + EMAIL_DESC_AMY + "   " + ADDRESS_DESC_AMY + " " + BIRTHDAY_DESC_AMY + "  " + TWITTER_DESC_AMY
+                + " " + INSTAGRAM_DESC_AMY + " " + DISPLAYPIC_DEFAULT + " " + TAG_DESC_FRIEND + " ";
         assertCommandSuccess(command, toAdd);
 
         /* Case: undo adding Amy to the list -> Amy deleted */
@@ -88,7 +94,7 @@ public class AddCommandSystemTest extends AddressBookSystemTest {
 
         /* Case: add a duplicate person -> rejected */
         command = AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY
-                + BIRTHDAY_DESC_AMY + DISPLAYPIC_DEFAULT + TAG_DESC_FRIEND;
+                + BIRTHDAY_DESC_AMY + TWITTER_DESC_AMY + INSTAGRAM_DESC_AMY + DISPLAYPIC_DEFAULT + TAG_DESC_FRIEND;
         assertCommandFailure(command, AddCommand.MESSAGE_DUPLICATE_PERSON);
 
         /* Case: add a duplicate person except with different tags -> rejected */
@@ -96,70 +102,77 @@ public class AddCommandSystemTest extends AddressBookSystemTest {
         // This test will fail is a new tag that is not in the model is used, see the bug documented in
         // AddressBook#addPerson(ReadOnlyPerson)
         command = AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY
-                + BIRTHDAY_DESC_AMY + DISPLAYPIC_DEFAULT + " " + PREFIX_TAG.getPrefix() + "friends";
+                + BIRTHDAY_DESC_AMY + TWITTER_DESC_AMY + INSTAGRAM_DESC_AMY
+                + DISPLAYPIC_DEFAULT + " " + PREFIX_TAG.getPrefix() + "friends";
         assertCommandFailure(command, AddCommand.MESSAGE_DUPLICATE_PERSON);
 
         /* Case: add a person with all fields same as another person in the address book except name -> added */
         toAdd = new PersonBuilder().withName(VALID_NAME_BOB).withPhone(VALID_PHONE_AMY).withEmail(VALID_EMAIL_AMY)
-                .withAddress(VALID_ADDRESS_AMY).withBirthday(VALID_BIRTHDAY_AMY)
-                .withDisplayPic(VALID_DISPLAYPIC).withTags(VALID_TAG_FRIEND).build();
+                .withAddress(VALID_ADDRESS_AMY).withBirthday(VALID_BIRTHDAY_AMY).withTwitter(VALID_TWITTER_AMY)
+                .withInstagram(VALID_INSTAGRAM_AMY).withDisplayPic(VALID_DISPLAYPIC).withTags(VALID_TAG_FRIEND).build();
         command = AddCommand.COMMAND_WORD + NAME_DESC_BOB + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY
-                + BIRTHDAY_DESC_AMY + DISPLAYPIC_DEFAULT + TAG_DESC_FRIEND;
+                + BIRTHDAY_DESC_AMY + TWITTER_DESC_AMY + INSTAGRAM_DESC_AMY
+                + DISPLAYPIC_DEFAULT + TAG_DESC_FRIEND;
         assertCommandSuccess(command, toAdd);
 
         /* Case: add a person with all fields same as another person in the address book except phone -> added */
         toAdd = new PersonBuilder().withName(VALID_NAME_AMY).withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_AMY)
-                .withAddress(VALID_ADDRESS_AMY).withBirthday(VALID_BIRTHDAY_AMY)
-                .withDisplayPic(VALID_DISPLAYPIC).withTags(VALID_TAG_FRIEND).build();
+                .withAddress(VALID_ADDRESS_AMY).withBirthday(VALID_BIRTHDAY_AMY).withTwitter(VALID_TWITTER_AMY)
+                .withInstagram(VALID_INSTAGRAM_AMY).withDisplayPic(VALID_DISPLAYPIC).withTags(VALID_TAG_FRIEND).build();
         command = AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_BOB + EMAIL_DESC_AMY + ADDRESS_DESC_AMY
-                + BIRTHDAY_DESC_AMY + DISPLAYPIC_DEFAULT + TAG_DESC_FRIEND;
+                + BIRTHDAY_DESC_AMY + TWITTER_DESC_AMY + INSTAGRAM_DESC_AMY + DISPLAYPIC_DEFAULT + TAG_DESC_FRIEND;
         assertCommandSuccess(command, toAdd);
 
         /* Case: add a person with all fields same as another person in the address book except email -> added */
         toAdd = new PersonBuilder().withName(VALID_NAME_AMY).withPhone(VALID_PHONE_AMY).withEmail(VALID_EMAIL_BOB)
-                .withAddress(VALID_ADDRESS_AMY).withBirthday(VALID_BIRTHDAY_AMY)
-                .withDisplayPic(VALID_DISPLAYPIC).withTags(VALID_TAG_FRIEND).build();
+                .withAddress(VALID_ADDRESS_AMY).withBirthday(VALID_BIRTHDAY_AMY).withTwitter(VALID_TWITTER_AMY)
+                .withInstagram(VALID_INSTAGRAM_AMY).withDisplayPic(VALID_DISPLAYPIC).withTags(VALID_TAG_FRIEND).build();
         command = AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_BOB + ADDRESS_DESC_AMY
-                + BIRTHDAY_DESC_AMY + DISPLAYPIC_DEFAULT + TAG_DESC_FRIEND;
+                + BIRTHDAY_DESC_AMY + TWITTER_DESC_AMY + INSTAGRAM_DESC_AMY + DISPLAYPIC_DEFAULT + TAG_DESC_FRIEND;
         assertCommandSuccess(command, toAdd);
 
         /* Case: add a person with all fields same as another person in the address book except address -> added */
         toAdd = new PersonBuilder().withName(VALID_NAME_AMY).withPhone(VALID_PHONE_AMY).withEmail(VALID_EMAIL_AMY)
-                .withAddress(VALID_ADDRESS_BOB).withBirthday(VALID_BIRTHDAY_AMY).withTags(VALID_TAG_FRIEND).build();
+                .withAddress(VALID_ADDRESS_BOB).withBirthday(VALID_BIRTHDAY_AMY)
+                .withTwitter(VALID_TWITTER_AMY).withInstagram(VALID_INSTAGRAM_AMY).withTags(VALID_TAG_FRIEND).build();
         command = AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_BOB
-                + BIRTHDAY_DESC_AMY + DISPLAYPIC_DEFAULT + TAG_DESC_FRIEND;
+                + BIRTHDAY_DESC_AMY + TWITTER_DESC_AMY + INSTAGRAM_DESC_AMY + DISPLAYPIC_DEFAULT + TAG_DESC_FRIEND;
         assertCommandSuccess(command, toAdd);
 
         /* Case: add a person with all fields same as another person in the address book except birthday -> added */
         toAdd = new PersonBuilder().withName(VALID_NAME_AMY).withPhone(VALID_PHONE_AMY).withEmail(VALID_EMAIL_AMY)
                 .withAddress(VALID_ADDRESS_AMY).withBirthday(VALID_BIRTHDAY_BOB)
+                .withTwitter(VALID_TWITTER_AMY).withInstagram(VALID_INSTAGRAM_AMY)
                 .withDisplayPic(VALID_DISPLAYPIC).withTags(VALID_TAG_FRIEND).build();
         command = AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY
-                + BIRTHDAY_DESC_BOB + DISPLAYPIC_DEFAULT + TAG_DESC_FRIEND;
+                + BIRTHDAY_DESC_BOB + TWITTER_DESC_AMY + INSTAGRAM_DESC_AMY + DISPLAYPIC_DEFAULT + TAG_DESC_FRIEND;
         assertCommandSuccess(command, toAdd);
 
         /* Case: no address -> added */
         toAdd = new PersonBuilder().withName(VALID_NAME_AMY).withPhone(VALID_PHONE_AMY).withEmail(VALID_EMAIL_AMY)
-                .withAddress("").withBirthday(VALID_BIRTHDAY_AMY)
-                .withDisplayPic(VALID_DISPLAYPIC).withTags(VALID_TAG_FRIEND).build();
+                .withAddress("").withBirthday(VALID_BIRTHDAY_AMY).withTwitter(VALID_TWITTER_AMY)
+                .withInstagram(VALID_INSTAGRAM_AMY).withDisplayPic(VALID_DISPLAYPIC)
+                .withTags(VALID_TAG_FRIEND).build();
         command = AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + INVALID_ADDRESS_DESC
-                + BIRTHDAY_DESC_AMY + DISPLAYPIC_DEFAULT + TAG_DESC_FRIEND;
+                + BIRTHDAY_DESC_AMY + TWITTER_DESC_AMY + INSTAGRAM_DESC_AMY + DISPLAYPIC_DEFAULT + TAG_DESC_FRIEND;
         assertCommandSuccess(command, toAdd);
 
         /* Case: no email -> added */
         toAdd = new PersonBuilder().withName(VALID_NAME_AMY).withPhone(VALID_PHONE_AMY).withEmail("")
-                .withAddress(VALID_ADDRESS_AMY).withBirthday(VALID_BIRTHDAY_AMY)
-                .withDisplayPic(VALID_DISPLAYPIC).withTags(VALID_TAG_FRIEND).build();
+                .withAddress(VALID_ADDRESS_AMY).withBirthday(VALID_BIRTHDAY_AMY).withTwitter(VALID_TWITTER_AMY)
+                .withInstagram(VALID_INSTAGRAM_AMY).withDisplayPic(VALID_DISPLAYPIC)
+                .withTags(VALID_TAG_FRIEND).build();
         command = AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY + ADDRESS_DESC_AMY + BIRTHDAY_DESC_AMY
-                + DISPLAYPIC_DEFAULT + TAG_DESC_FRIEND;
+                + TWITTER_DESC_AMY + INSTAGRAM_DESC_AMY + DISPLAYPIC_DEFAULT + TAG_DESC_FRIEND;
         assertCommandSuccess(command, toAdd);
 
         /* Case: no birthday -> added */
         toAdd = new PersonBuilder().withName(VALID_NAME_AMY).withPhone(VALID_PHONE_AMY).withEmail(VALID_EMAIL_AMY)
-                .withAddress(VALID_ADDRESS_AMY).withBirthday("")
+                .withAddress(VALID_ADDRESS_AMY).withBirthday("").withTwitter(VALID_TWITTER_AMY)
+                .withInstagram(VALID_INSTAGRAM_AMY)
                 .withDisplayPic(VALID_DISPLAYPIC).withTags(VALID_TAG_FRIEND).build();
         command = AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY
-                + DISPLAYPIC_DEFAULT + TAG_DESC_FRIEND;
+                + TWITTER_DESC_AMY + INSTAGRAM_DESC_AMY + DISPLAYPIC_DEFAULT + TAG_DESC_FRIEND;
         assertCommandSuccess(command, toAdd);
 
         /* Case: filters the person list before adding -> added */
@@ -176,7 +189,8 @@ public class AddCommandSystemTest extends AddressBookSystemTest {
         /* Case: add a person with tags, command with parameters in random order -> added */
         toAdd = BOB;
         command = AddCommand.COMMAND_WORD + TAG_DESC_FRIEND + PHONE_DESC_BOB + ADDRESS_DESC_BOB + NAME_DESC_BOB
-                + TAG_DESC_HUSBAND + EMAIL_DESC_BOB + BIRTHDAY_DESC_BOB + DISPLAYPIC_DEFAULT;
+                + TAG_DESC_HUSBAND + EMAIL_DESC_BOB + BIRTHDAY_DESC_BOB + TWITTER_DESC_BOB + INSTAGRAM_DESC_BOB
+                + DISPLAYPIC_DEFAULT;
         assertCommandSuccess(command, toAdd);
 
         /* Case: selects first card in the person list, add a person -> added, card selection remains unchanged */
@@ -189,12 +203,12 @@ public class AddCommandSystemTest extends AddressBookSystemTest {
 
         /* Case: missing name -> rejected */
         command = AddCommand.COMMAND_WORD + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + BIRTHDAY_DESC_AMY
-                + DISPLAYPIC_DEFAULT;
+                + INSTAGRAM_DESC_AMY + TWITTER_DESC_AMY + DISPLAYPIC_DEFAULT;
         assertCommandFailure(command, String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
 
         /* Case: missing phone -> rejected */
         command = AddCommand.COMMAND_WORD + NAME_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + BIRTHDAY_DESC_AMY
-                + DISPLAYPIC_DEFAULT;
+                + INSTAGRAM_DESC_AMY + TWITTER_DESC_AMY + DISPLAYPIC_DEFAULT;
         assertCommandFailure(command, String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
 
         /* Case: invalid keyword -> rejected */
@@ -203,27 +217,28 @@ public class AddCommandSystemTest extends AddressBookSystemTest {
 
         /* Case: invalid name -> rejected */
         command = AddCommand.COMMAND_WORD + INVALID_NAME_DESC + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY
-                + BIRTHDAY_DESC_AMY + DISPLAYPIC_DEFAULT;
+                + INSTAGRAM_DESC_AMY + TWITTER_DESC_AMY + BIRTHDAY_DESC_AMY + DISPLAYPIC_DEFAULT;
         assertCommandFailure(command, Name.MESSAGE_NAME_CONSTRAINTS);
 
         /* Case: invalid phone -> rejected */
         command = AddCommand.COMMAND_WORD + NAME_DESC_AMY + INVALID_PHONE_DESC + EMAIL_DESC_AMY + ADDRESS_DESC_AMY
-                + BIRTHDAY_DESC_AMY + DISPLAYPIC_DEFAULT;
+                + INSTAGRAM_DESC_AMY + TWITTER_DESC_AMY + BIRTHDAY_DESC_AMY + DISPLAYPIC_DEFAULT;
         assertCommandFailure(command, Phone.MESSAGE_PHONE_CONSTRAINTS);
 
         /* Case: invalid email -> rejected */
         command = AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY + INVALID_EMAIL_DESC + ADDRESS_DESC_AMY
-                + BIRTHDAY_DESC_AMY + DISPLAYPIC_DEFAULT;
+                + INSTAGRAM_DESC_AMY + TWITTER_DESC_AMY + BIRTHDAY_DESC_AMY + DISPLAYPIC_DEFAULT;
         assertCommandFailure(command, Email.MESSAGE_EMAIL_CONSTRAINTS);
 
         /* Case: invalid birthday -> rejected */
         command = AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY
+                + INSTAGRAM_DESC_AMY + TWITTER_DESC_AMY
                 + INVALID_BIRTHDAY_DESC + DISPLAYPIC_DEFAULT;
         assertCommandFailure(command, Birthday.MESSAGE_BIRTHDAY_CONSTRAINTS);
 
         /* Case: invalid tag -> rejected */
         command = AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY
-                + BIRTHDAY_DESC_AMY + DISPLAYPIC_DEFAULT + INVALID_TAG_DESC;
+                + INSTAGRAM_DESC_AMY + TWITTER_DESC_AMY + BIRTHDAY_DESC_AMY + DISPLAYPIC_DEFAULT + INVALID_TAG_DESC;
         assertCommandFailure(command, Tag.MESSAGE_TAG_CONSTRAINTS);
     }
 

--- a/src/test/java/systemtests/EditCommandSystemTest.java
+++ b/src/test/java/systemtests/EditCommandSystemTest.java
@@ -8,6 +8,8 @@ import static seedu.address.logic.commands.CommandTestUtil.BIRTHDAY_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.BIRTHDAY_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.INSTAGRAM_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.INSTAGRAM_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_BIRTHDAY_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_EMAIL_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
@@ -19,13 +21,17 @@ import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_FRIEND;
 import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_HUSBAND;
+import static seedu.address.logic.commands.CommandTestUtil.TWITTER_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.TWITTER_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_BIRTHDAY_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_INSTAGRAM_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TWITTER_BOB;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
@@ -68,9 +74,10 @@ public class EditCommandSystemTest extends AddressBookSystemTest {
         Index index = INDEX_FIRST_PERSON;
         String command = " " + EditCommand.COMMAND_WORD + "  " + index.getOneBased() + "  " + NAME_DESC_BOB + "  "
                 + PHONE_DESC_BOB + " " + EMAIL_DESC_BOB + "  " + ADDRESS_DESC_BOB + " " + BIRTHDAY_DESC_BOB + " "
-                + TAG_DESC_HUSBAND + " ";
+                + TWITTER_DESC_BOB + " " + INSTAGRAM_DESC_BOB + " " + TAG_DESC_HUSBAND + " ";
         Person editedPerson = new PersonBuilder().withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
                 .withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB).withBirthday(VALID_BIRTHDAY_BOB)
+                .withTwitter(VALID_TWITTER_BOB).withInstagram(VALID_INSTAGRAM_BOB)
                 .withTags(VALID_TAG_HUSBAND).build();
         assertCommandSuccess(command, index, editedPerson);
 
@@ -89,7 +96,8 @@ public class EditCommandSystemTest extends AddressBookSystemTest {
         /* Case: edit a person with new values same as existing values -> edited */
         index = INDEX_SECOND_PERSON; //sort puts Bob in 2nd
         command = EditCommand.COMMAND_WORD + " " + index.getOneBased() + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                + ADDRESS_DESC_BOB + BIRTHDAY_DESC_BOB + TAG_DESC_FRIEND + TAG_DESC_HUSBAND;
+                + ADDRESS_DESC_BOB + BIRTHDAY_DESC_BOB + TWITTER_DESC_BOB
+                + INSTAGRAM_DESC_BOB + TAG_DESC_FRIEND + TAG_DESC_HUSBAND;
         assertCommandSuccess(command, index, BOB);
 
         /* Case: edit some fields -> edited */
@@ -133,7 +141,7 @@ public class EditCommandSystemTest extends AddressBookSystemTest {
         index = INDEX_FIRST_PERSON;
         selectPerson(index);
         command = EditCommand.COMMAND_WORD + " " + index.getOneBased() + NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY
-                + ADDRESS_DESC_AMY + BIRTHDAY_DESC_AMY + TAG_DESC_FRIEND;
+                + ADDRESS_DESC_AMY + BIRTHDAY_DESC_AMY + TWITTER_DESC_AMY + INSTAGRAM_DESC_AMY  + TAG_DESC_FRIEND;
         // this can be misleading: card selection actually remains unchanged but the
         // browser's url is updated to reflect the new person's name
         assertCommandSuccess(command, index, AMY, index);
@@ -192,12 +200,13 @@ public class EditCommandSystemTest extends AddressBookSystemTest {
         index = INDEX_FIRST_PERSON;
         assertFalse(getModel().getFilteredPersonList().get(index.getZeroBased()).equals(BOB));
         command = EditCommand.COMMAND_WORD + " " + index.getOneBased() + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                + ADDRESS_DESC_BOB + BIRTHDAY_DESC_BOB + TAG_DESC_FRIEND + TAG_DESC_HUSBAND;
+                + ADDRESS_DESC_BOB + BIRTHDAY_DESC_BOB + TWITTER_DESC_BOB
+                + INSTAGRAM_DESC_BOB + TAG_DESC_FRIEND + TAG_DESC_HUSBAND;
         assertCommandFailure(command, EditCommand.MESSAGE_DUPLICATE_PERSON);
 
         /* Case: edit a person with new values same as another person's values but with different tags -> rejected */
         command = EditCommand.COMMAND_WORD + " " + index.getOneBased() + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                + ADDRESS_DESC_BOB + BIRTHDAY_DESC_BOB + TAG_DESC_HUSBAND;
+                + ADDRESS_DESC_BOB + BIRTHDAY_DESC_BOB + TWITTER_DESC_BOB + INSTAGRAM_DESC_BOB + TAG_DESC_HUSBAND;
         assertCommandFailure(command, EditCommand.MESSAGE_DUPLICATE_PERSON);
     }
 

--- a/src/test/java/systemtests/EditCommandSystemTest.java
+++ b/src/test/java/systemtests/EditCommandSystemTest.java
@@ -12,9 +12,11 @@ import static seedu.address.logic.commands.CommandTestUtil.INSTAGRAM_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.INSTAGRAM_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_BIRTHDAY_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_EMAIL_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_INSTAGRAM_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_PHONE_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_TAG_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_TWITTER_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
@@ -54,6 +56,7 @@ import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
 import seedu.address.model.person.ReadOnlyPerson;
+import seedu.address.model.person.UserName;
 import seedu.address.model.person.exceptions.DuplicatePersonException;
 import seedu.address.model.person.exceptions.PersonNotFoundException;
 import seedu.address.model.tag.Tag;
@@ -188,6 +191,16 @@ public class EditCommandSystemTest extends AddressBookSystemTest {
         assertCommandFailure(EditCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased()
                         + INVALID_BIRTHDAY_DESC,
                 Birthday.MESSAGE_BIRTHDAY_CONSTRAINTS);
+
+        /* Case: invalid twitter username -> rejected */
+        assertCommandFailure(EditCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased()
+                        + INVALID_TWITTER_DESC,
+                UserName.MESSAGE_USERNAME_CONSTRAINTS);
+
+        /* Case: invalid instagram username -> rejected */
+        assertCommandFailure(EditCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased()
+                        + INVALID_INSTAGRAM_DESC,
+                UserName.MESSAGE_USERNAME_CONSTRAINTS);
 
         /* Case: invalid tag -> rejected */
         assertCommandFailure(EditCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased()


### PR DESCRIPTION
v1.4
- Added the ability for a user to add in their contacts' instagram and twitter accounts as a field for easy access (in a later iteration of the application) and reference.

- Add/Edit system tests have been updated to match the new functionality
